### PR TITLE
Alvik instance error

### DIFF
--- a/arduino_alvik/arduino_alvik.py
+++ b/arduino_alvik/arduino_alvik.py
@@ -1,5 +1,4 @@
 import sys
-import gc
 import struct
 from machine import I2C
 import _thread
@@ -83,6 +82,14 @@ class ArduinoAlvik:
         self._touch_events = _ArduinoAlvikTouchEvents()
         self._move_events = _ArduinoAlvikMoveEvents()
         self._timer_events = _ArduinoAlvikTimerEvents(-1)
+
+    def __del__(self):
+        """
+        This method is a stub. __del__ is not implemented in MicroPython (https://docs.micropython.org/en/latest/genrst/core_language.html#special-method-del-not-implemented-for-user-defined-classes)
+        :return:
+        """
+        ...
+        # self.__class__._instance = None
 
     @staticmethod
     def is_on() -> bool:
@@ -376,10 +383,6 @@ class ArduinoAlvik:
 
         # stop touch events thread
         self._stop_events_thread()
-
-        # delete _instance
-        del self.__class__._instance
-        gc.collect()
 
     @staticmethod
     def _reset_hw():


### PR DESCRIPTION
On multiple calls to ArduinoAlvik.stop you got the following exception:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/arduino_alvik/arduino_alvik.py", line 381, in stop
AttributeError: 'type' object has no attribute '_instance'
```

Unbinding the current instance from the ArduinoAlvik singleton class in the stop method is IMO useless and has potential side effects like:
- If one alvik obj is stopped and another one is created you will have 2 instances of ArduinoAlvik which beats the purpose of the singleton class

The right way would be unbinding the instance right before it is deleted. Unfortunately the special method '__del__' is not implemented in MP for user defined classes, see [here](https://docs.micropython.org/en/latest/genrst/core_language.html#special-method-del-not-implemented-for-user-defined-classes)