### PR TITLE
feat: _wait_for_fw_check timeout on unavailable FW version

### DIFF
--- a/arduino_alvik/arduino_alvik.py
+++ b/arduino_alvik/arduino_alvik.py
@@ -254,13 +254,19 @@ class ArduinoAlvik:
             sleep_ms(20)
         self._waiting_ack = None
 
-    def _wait_for_fw_check(self) -> bool:
+    def _wait_for_fw_check(self, timeout=5) -> bool:
         """
         Waits until receives version from robot, check required version and return true if everything is ok
+        :param timeout: wait for fw timeout in seconds
         :return:
         """
+        start = ticks_ms()
         while self._fw_version == [None, None, None]:
             sleep_ms(20)
+            if ticks_diff(ticks_ms(), start) < timeout * 1000:
+                print("Could not get FW version")
+                return False
+
         if self.check_firmware_compatibility():
             return True
         else:


### PR DESCRIPTION
A blocking _wait_for_fw_check can be an issue during testing if UART is not responding
This PR implements a timeout to _wait_for_fw_check and prints a warning to the REPL if timeout is expired