### PR TITLE
fix: reimport all the modules before flashing a new FW

### DIFF
--- a/examples/flash_firmware.py
+++ b/examples/flash_firmware.py
@@ -1,4 +1,19 @@
-# from machine import reset
+import sys
+
+
+def reload_modules():
+    to_be_reloaded = []
+
+    for m in sys.modules:
+        to_be_reloaded.append(m)
+        del sys.modules[m]
+
+    for m in to_be_reloaded:
+        print(f"Reloading {m}")
+        exec(f'import {m}')
+
+
+reload_modules()
 from arduino_alvik import update_firmware
 
 # this is a patch to fix possible running threads on Alvik
@@ -6,5 +21,4 @@ from arduino_alvik import ArduinoAlvik
 alvik = ArduinoAlvik()
 alvik.stop()
 
-update_firmware('./firmware.bin')
-# reset()
+update_firmware('/firmware.bin')

--- a/examples/flash_firmware.py
+++ b/examples/flash_firmware.py
@@ -9,7 +9,6 @@ def reload_modules():
         del sys.modules[m]
 
     for m in to_be_reloaded:
-        print(f"Reloading {m}")
         exec(f'import {m}')
 
 


### PR DESCRIPTION
Reloading system modules before flashing the carrier firmware ensures that the most recent version of the alvik library is used